### PR TITLE
Fixed infinite loop when server returns an error

### DIFF
--- a/src/ManageSieve/Client.php
+++ b/src/ManageSieve/Client.php
@@ -246,7 +246,7 @@ class Client implements SieveClient
                 if (StringUtils::endsWith($response, "\r\n")) {
                     $response .= $this->readLine() . "\r\n";
                 }
-                continue;
+                break;
             }
 
             if (!strlen($line)) {


### PR DESCRIPTION
Any server side error makes sieve manager to do an infinite looping.