### PR TITLE
Fixed infinite loop when an error occurs on server

### DIFF
--- a/src/ManageSieve/Client.php
+++ b/src/ManageSieve/Client.php
@@ -96,11 +96,6 @@ class Client implements SieveClient
         }
 
         if (strlen($return)) {
-            preg_match($this->sizeExpression, $return, $matches);
-            if (count($matches)) {
-                throw new LiteralException($matches[1]);
-            }
-
             preg_match($this->respCodeExpression, $return, $matches);
             if (count($matches)) {
                 if (strpos($matches[0], "NOTIFY") !== false) {
@@ -113,6 +108,11 @@ class Client implements SieveClient
                         $this->parseError($matches[2]);
                 }
                 throw new ResponseException($matches[1], $matches[2]);
+            }
+
+            preg_match($this->sizeExpression, $return, $matches);
+            if (count($matches)) {
+                throw new LiteralException($matches[1]);
             }
         }
 
@@ -246,7 +246,7 @@ class Client implements SieveClient
                 if (StringUtils::endsWith($response, "\r\n")) {
                     $response .= $this->readLine() . "\r\n";
                 }
-                break;
+                continue;
             }
 
             if (!strlen($line)) {


### PR DESCRIPTION
I changed the exception calling order to be correct. Responses comes with NO/YES/BYE at the very beginning of line and then the code size comes after. This fix makes postale.io to not look over and over. When the response comes as: `NO {265} main_script: line 3: warning: included personal script 'blocked_senders' does not exist (ignored during upload). main_script: line 3: error: failed to include script 'blocked_senders': no more than 0 includes allowed. main_script: error: code generation failed.`