### PR TITLE
Consume buffer in multiline error

### DIFF
--- a/src/ManageSieve/Client.php
+++ b/src/ManageSieve/Client.php
@@ -182,6 +182,7 @@ class Client implements SieveClient
             list($nextLine, $_) = $this->getSingleLine();
             if (preg_match('/^\d+$/', trim($errorMessage)) && preg_match('/error:/i', $nextLine)) {
                 $this->errorMessage = $nextLine;
+                $this->readBlock($errorMessage);
             } else {
                 $this->errorMessage = $this->readBlock($errorMessage);
             }


### PR DESCRIPTION
Multi-line error messages aren't consumed from the socket, and end up bleeding into whatever the next call happens to be.

Example: if I do a `putScript()` with a compile error and then call `listScripts()` after that, the first two "scripts" it returns are the error messages from the `putScript()`.

My fix is to simply call `readBlock()` to consume the socket buffer.